### PR TITLE
Tweak R CI to work with `ubuntu-latest`, add cancellation of in-progress CI

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -9,6 +9,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 name: pkgdown
 
 jobs:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,16 +25,14 @@ jobs:
       pages: write
     steps:
       - uses: actions/checkout@v3
+      
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: "2.19.2"
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: "4.3.1"
-          use-public-rspm: true
-          install-r: false
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,7 +25,7 @@ jobs:
       pages: write
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,7 +11,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v5
-    - uses: actions/setup-r@v2
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
     - uses: actions/cache@v4
       with:
         path: "~/.cache/R/renv"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v5
+    - uses: actions/setup-r@v2
     - uses: actions/cache@v4
       with:
         path: "~/.cache/R/renv"

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-package:
     strategy:


### PR DESCRIPTION
- Deal with the fact that R is preinstalled on `ubuntu-22.04` GH actions runners but not on `ubuntu-24.04` runners
- Add cancel-in-progress concurrency control for workflows