### PR TITLE
Add tests for `pull_nhsn`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
 #####
 # R
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9001
+    rev: v0.4.3
     hooks:
       - id: style-files
       - id: deps-in-desc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,8 +62,8 @@ Suggests:
     usethis,
     testthat (>= 3.0.0),
     rcmdcheck,
-    httptest,
-    withr
+    withr,
+    httptest2
 VignetteBuilder:
     knitr
 URL: https://cdcgov.github.io/forecasttools/, https://github.com/CDCgov/forecasttools/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,8 @@ Suggests:
     testthat (>= 3.0.0),
     rcmdcheck,
     withr,
-    httptest2
+    httptest2,
+    httptest
 VignetteBuilder:
     knitr
 URL: https://cdcgov.github.io/forecasttools/, https://github.com/CDCgov/forecasttools/

--- a/R/categorize_vector.R
+++ b/R/categorize_vector.R
@@ -18,12 +18,13 @@
 #' to use for all values, as a one-entry list containing a
 #' single character vector.
 #' @param include.lowest Passed to [base::cut()]. Default `TRUE`.
-#' @param order Passed to [base::cut()]. Default `TRUE`.
+#' @param order Should the output factors be ordered factors?
+#' Passed to [base::cut()]. Default `TRUE`.
 #' @param right Passed to [base::cut()]. Default `TRUE`.
 #' @param ... Additional keyword arguments passed to
 #' [base::cut()].
-#' @return A categorized vector, as vector of ordered
-#' factors.
+#' @return A categorized vector, as vector of
+#' factors (default ordered factors).
 #' @export
 categorize_vector <- function(values,
                               break_sets,

--- a/R/pull_nhsn.R
+++ b/R/pull_nhsn.R
@@ -186,13 +186,9 @@ nhsn_soda_query <- function(api_endpoint,
     ) |>
     soql_nullable_is_in(
       "jurisdiction", jurisdictions
-    ) |>
-    soql::soql_order(
-      paste(unique(order_by),
-        collapse = ","
-      ),
-      desc = desc
     )
+
+  for (x in unique(order_by)) query <- soql::soql_order(query, x, desc = desc)
 
   ## do limit string formatting
   ## manually since soql::soql_limit()

--- a/R/pull_nhsn.R
+++ b/R/pull_nhsn.R
@@ -188,6 +188,8 @@ nhsn_soda_query <- function(api_endpoint,
       "jurisdiction", jurisdictions
     )
 
+  ## need to add order_by columns sequentially
+  ## to ensure the specified desc option is applied to each
   for (x in unique(order_by)) query <- soql::soql_order(query, x, desc = desc)
 
   ## do limit string formatting

--- a/man/categorize_vector.Rd
+++ b/man/categorize_vector.Rd
@@ -33,7 +33,8 @@ single character vector.}
 
 \item{include.lowest}{Passed to \code{\link[base:cut]{base::cut()}}. Default \code{TRUE}.}
 
-\item{order}{Passed to \code{\link[base:cut]{base::cut()}}. Default \code{TRUE}.}
+\item{order}{Should the output factors be ordered factors?
+Passed to \code{\link[base:cut]{base::cut()}}. Default \code{TRUE}.}
 
 \item{right}{Passed to \code{\link[base:cut]{base::cut()}}. Default \code{TRUE}.}
 
@@ -41,8 +42,8 @@ single character vector.}
 \code{\link[base:cut]{base::cut()}}.}
 }
 \value{
-A categorized vector, as vector of ordered
-factors.
+A categorized vector, as vector of
+factors (default ordered factors).
 }
 \description{
 Vectorized version of \code{\link[base:cut]{base::cut()}} that

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,1 +1,1 @@
-library(httptest)
+library(httptest2)

--- a/tests/testthat/test_pull_nhsn.R
+++ b/tests/testthat/test_pull_nhsn.R
@@ -1,0 +1,94 @@
+start_date <- "2023-01-01"
+end_date <- "2023-10-31"
+jurisdictions <- c("CA", "TX")
+
+mockdir <- "api_mocks"
+
+with_mock_dir(mockdir, {
+  test_that("Warnings raised if API key/secret not provided", {
+    expect_warning(pull_nhsn(
+      api_key_id = NULL, api_key_secret = NULL,
+      limit = 10,
+      error_on_limit = FALSE
+    ))
+  })
+
+  test_that(paste0(
+    "Filters by start_date, end_date, and ",
+    "jurisdiction work as expected"
+  ), {
+    result <- pull_nhsn(
+      start_date = start_date, end_date = end_date,
+      jurisdictions = jurisdictions
+    )
+
+    expect_true(all(result$weekendingdate >= as.Date(start_date)))
+    expect_true(all(result$weekendingdate <= as.Date(end_date)))
+    expect_setequal(result$jurisdiction, jurisdictions)
+  })
+
+  test_that("Selection of columns works as expected", {
+    columns <- c("numinptbeds", "totalconfc19newadmped")
+
+    result <- pull_nhsn(
+      columns = columns,
+      limit = 10,
+      error_on_limit = FALSE
+    )
+
+    expected_columns <- c("jurisdiction", "weekendingdate", columns)
+    checkmate::expect_names(
+      colnames(result),
+      identical.to = expected_columns
+    )
+  })
+
+  test_that("ordering via order_by and desc works as expected", {
+    columns <- c("numinptbeds", "totalconfc19newadmped")
+
+    order_by <- c("weekendingdate", "jurisdiction")
+
+    result_asc <- pull_nhsn(
+      start_date = start_date,
+      end_date = end_date,
+      jurisdictions = jurisdictions,
+      columns = columns,
+      order_by = order_by,
+      desc = FALSE
+    )
+    result_desc <- pull_nhsn(
+      start_date = start_date,
+      end_date = end_date,
+      jurisdictions = jurisdictions,
+      columns = columns,
+      order_by = order_by,
+      desc = TRUE
+    )
+
+
+    expect_equal(
+      result_asc,
+      result_desc |>
+        dplyr::arrange(
+          .data$weekendingdate,
+          .data$jurisdiction
+        )
+    )
+    expect_equal(
+      result_desc,
+      result_asc |>
+        dplyr::arrange(
+          dplyr::desc(.data$weekendingdate),
+          dplyr::desc(.data$jurisdiction)
+        )
+    )
+  })
+
+  test_that("limit and error_on_limit work as expected", {
+    limit <- 10
+    result <- pull_nhsn(limit = limit, error_on_limit = FALSE)
+    expect_equal(nrow(result), limit)
+
+    expect_error(pull_nhsn(limit = limit, error_on_limit = TRUE))
+  })
+})

--- a/vignettes/pull-nhsn.Rmd
+++ b/vignettes/pull-nhsn.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-httptest::start_vignette("pull-nhsn")
+httptest2::start_vignette("pull-nhsn")
 ```
 
 In this vignette you will learn how use `forecasttools` to pull data from the [National Healthcare Safety Network (NHSN)](https://www.cdc.gov/nhsn/index.html) [Weekly Hospital Respiratory Data (HRD)](https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/ua7e-t2fy/about_data) dataset. This dataset contains counts of epiweekly influenza and COVID-19 hospital admissions by U.S. state, among other quantities.
@@ -113,5 +113,5 @@ influenza_by_date
 ```
 
 ```{r, include=FALSE}
-httptest::end_vignette()
+httptest2::end_vignette()
 ```

--- a/vignettes/pull-nhsn.Rmd
+++ b/vignettes/pull-nhsn.Rmd
@@ -12,8 +12,9 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-httptest2::start_vignette("pull-nhsn")
+httptest::start_vignette("pull-nhsn")
 ```
+
 
 In this vignette you will learn how use `forecasttools` to pull data from the [National Healthcare Safety Network (NHSN)](https://www.cdc.gov/nhsn/index.html) [Weekly Hospital Respiratory Data (HRD)](https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/ua7e-t2fy/about_data) dataset. This dataset contains counts of epiweekly influenza and COVID-19 hospital admissions by U.S. state, among other quantities.
 
@@ -113,5 +114,5 @@ influenza_by_date
 ```
 
 ```{r, include=FALSE}
-httptest2::end_vignette()
+httptest::end_vignette()
 ```


### PR DESCRIPTION
- Adds tests with mock api calls for `pull_nhsn`
- Fixes a bug in `order_by` behavior that the tests caught.
- Also makes a minor docs tweak to `categorize_vector`
- Moves from using `httptest` to the newer `httptest2`