### PR TITLE
Adapt hubverse to scorable functions to allow for multiple targets

### DIFF
--- a/R/hubverse_to_scorable.R
+++ b/R/hubverse_to_scorable.R
@@ -14,9 +14,6 @@
 #' @param obs_value_column Name of the column containing
 #' observed values in the `observed` table, as a string.
 #' Default `"value"`
-#' @param obs_location_column Name of the column containing
-#' location values in the `observed` table, as a string.
-#' Default `"location"`
 #' @param obs_date_column Name of the column containing
 #' date values in the `observed` table, as a string. Will
 #' be joined to the `target_end_date` column in the hubverse

--- a/R/hubverse_to_scorable.R
+++ b/R/hubverse_to_scorable.R
@@ -174,7 +174,8 @@ hub_to_scorable_quantiles <-
              "target-hospital-admissions.csv"
            ),
            ...) {
-    quantile_forecasts <- gather_hub_quantile_forecasts(hub_path)
+    quantile_forecasts <- gather_hub_quantile_forecasts(hub_path) |>
+      dplyr::rename(model = "model_id")
     target_data <- gather_hub_target_data(
       hub_path,
       target_data_rel_path =

--- a/man/hubverse_table_with_obs.Rd
+++ b/man/hubverse_table_with_obs.Rd
@@ -8,9 +8,9 @@ hubverse_table_with_obs(
   hubverse_forecast_table,
   observation_table,
   obs_value_column = "value",
-  obs_location_column = "location",
   obs_date_column = "date",
   obs_value_name = "observed",
+  id_cols = c("location", "target"),
   join = "full"
 )
 }
@@ -26,17 +26,17 @@ and \code{location}.}
 observed values in the \code{observed} table, as a string.
 Default \code{"value"}}
 
-\item{obs_location_column}{Name of the column containing
-location values in the \code{observed} table, as a string.
-Default \code{"location"}}
-
 \item{obs_date_column}{Name of the column containing
-date values in the \code{observed} table, as a string.
-Default \code{"date"}}
+date values in the \code{observed} table, as a string. Will
+be joined to the \code{target_end_date} column in the hubverse
+table. Default \code{"date"}}
 
 \item{obs_value_name}{Name for the column of observed values
 in the resulting table (since \code{"value"} clashes with the forecast
 value column in a standard hubverse table. Default \code{"observed"}.}
+
+\item{id_cols}{Additional ID columns to join on, in addition to
+\code{obs_date_column}. Default \code{c("location", "target")}.}
 
 \item{join}{Which SQL-style \code{dplyr} \link[dplyr:mutate-joins]{mutating join}
 function to use when joining the tables. Options are \code{"full"}
@@ -48,6 +48,10 @@ In the join, the hubverse forecast table is the left table
 Default \code{"full"} (i.e. keep all forecasts and observations,
 even if some forecasts do not have a corresponding observation or
 some observations do not have a corresponding forecast).}
+
+\item{obs_location_column}{Name of the column containing
+location values in the \code{observed} table, as a string.
+Default \code{"location"}}
 }
 \value{
 A \code{\link[tibble:tibble]{tibble}} with the observed values

--- a/man/hubverse_table_with_obs.Rd
+++ b/man/hubverse_table_with_obs.Rd
@@ -48,10 +48,6 @@ In the join, the hubverse forecast table is the left table
 Default \code{"full"} (i.e. keep all forecasts and observations,
 even if some forecasts do not have a corresponding observation or
 some observations do not have a corresponding forecast).}
-
-\item{obs_location_column}{Name of the column containing
-location values in the \code{observed} table, as a string.
-Default \code{"location"}}
 }
 \value{
 A \code{\link[tibble:tibble]{tibble}} with the observed values

--- a/man/quantile_table_to_scorable.Rd
+++ b/man/quantile_table_to_scorable.Rd
@@ -8,8 +8,8 @@ quantile_table_to_scorable(
   hubverse_quantile_table,
   observation_table,
   obs_value_column = "value",
-  obs_location_column = "location",
   obs_date_column = "date",
+  id_cols = c("location", "target"),
   quantile_tol = 10
 )
 }
@@ -20,19 +20,21 @@ as produced by \code{\link[=get_hubverse_table]{get_hubverse_table()}}, with col
 \code{location}, \code{target_end_date}, \code{output_type}, \code{output_type_id},
 and \code{value}.}
 
-\item{observation_table}{observations, as a \code{\link[tibble:tibble]{tibble}}.}
+\item{observation_table}{observations, as a
+\code{\link[tibble:tibble]{tibble}}.}
 
 \item{obs_value_column}{Name of the column containing
 observed values in the \code{observed} table, as a string.
 Default \code{"value"}}
 
-\item{obs_location_column}{Name of the column containing
-location values in the \code{observed} table, as a string.
-Default \code{"location"}}
-
 \item{obs_date_column}{Name of the column containing
 date values in the \code{observed} table, as a string.
-Default \code{"date"}}
+Default \code{"date"}.}
+
+\item{id_cols}{Additional id columns for joining the
+\verb{observation table} to the \code{hubverse_quantile_table}.
+Passed to \code{\link[=hubverse_table_with_obs]{hubverse_table_with_obs()}}. Default
+\code{c("location", "target")}.}
 
 \item{quantile_tol}{Round quantile level values to this many
 decimal places, to avoid problems with floating point number

--- a/tests/testthat/test_to_scorable.R
+++ b/tests/testthat/test_to_scorable.R
@@ -1,18 +1,22 @@
-create_hubverse_table <- function(
-    date_cols, horizon, location, output_type, output_type_id) {
+create_hubverse_table <- function(date_cols,
+                                  horizon,
+                                  location,
+                                  output_type,
+                                  output_type_id,
+                                  target) {
   data <- tidyr::expand_grid(
     reference_date = date_cols,
     horizon = horizon,
     output_type_id = output_type_id,
-    location = location
+    location = location,
+    target = target
   ) |>
-    dplyr::group_by(reference_date, horizon, location) |>
+    dplyr::group_by(reference_date, horizon, location, target) |>
     dplyr::mutate(
       value = sort(
         sample(1:100, dplyr::n(), replace = TRUE),
         decreasing = FALSE
       ),
-      target = "wk inc covid prop ed visits",
       output_type = "quantile",
       target_end_date = reference_date + 7 * horizon
     ) |>
@@ -23,39 +27,78 @@ create_hubverse_table <- function(
 
 
 create_observation_data <- function(
-    date_cols, location_cols) {
+    date, location, target) {
   data <- tidyr::expand_grid(
-    reference_date = date_cols,
-    location = location_cols
+    reference_date = date,
+    location = location,
+    target = target
   ) |>
     dplyr::mutate(value = sample(1:100, dplyr::n(), replace = TRUE))
   return(data)
 }
 
+forecast <- create_hubverse_table(
+  date_cols = seq(
+    lubridate::ymd("2023-11-01"), lubridate::ymd("2024-01-29"),
+    by = "day"
+  ),
+  horizon = c(0, 1, 2),
+  location = c("loc1", "loc2"),
+  target = c(
+    "wk inc pathogen ed visits",
+    "daily prev pathogen admissions"
+  ),
+  output_type = "quantile",
+  output_type_id = c(0.01, 0.025, 1:19 / 20, 0.975, 0.99)
+)
+
+observed <- create_observation_data(
+  date = seq(
+    lubridate::ymd("2023-11-01"), lubridate::ymd("2024-01-29"),
+    by = "day"
+  ),
+  location = c("loc1", "loc2"),
+  target = c(
+    "wk inc pathogen ed visits",
+    "daily prev pathogen admissions"
+  )
+)
+
+
+testthat::test_that(paste0(
+  "hubverse_table_with_obs errors ",
+  "when needed columns are missing"
+), {
+  expect_error(
+    hubverse_table_with_obs(
+      forecast,
+      observed,
+      obs_value_column = "wrong"
+    ),
+    "wrong"
+  )
+  expect_error(
+    hubverse_table_with_obs(
+      forecast,
+      observed,
+      obs_date_column = "not_in_table"
+    ),
+    "not_in_table"
+  )
+  expect_error(
+    hubverse_table_with_obs(
+      forecast,
+      observed,
+      id_cols = "missing_id_col"
+    ),
+    "missing_id_col"
+  )
+})
 
 testthat::test_that(paste0(
   "quantile_table_to_scorable works as expected ",
-  "with valid inputs"
+  "with valid default inputs"
 ), {
-  forecast <- create_hubverse_table(
-    date_cols = seq(
-      lubridate::ymd("2023-11-01"), lubridate::ymd("2024-01-29"),
-      by = "day"
-    ),
-    horizon = c(0, 1, 2),
-    location = c("loc1", "loc2"),
-    output_type = "quantile",
-    output_type_id = c(0.01, 0.025, 1:19 / 20, 0.975, 0.99)
-  )
-
-  observed <- create_observation_data(
-    date_cols = seq(
-      lubridate::ymd("2023-11-01"), lubridate::ymd("2024-01-29"),
-      by = "day"
-    ),
-    location = c("loc1", "loc2")
-  )
-
   scorable <- quantile_table_to_scorable(
     forecast,
     observed,
@@ -63,27 +106,59 @@ testthat::test_that(paste0(
   )
   expect_true(scoringutils::is_forecast_quantile(scorable))
   expect_setequal(forecast$location, scorable$location)
+  expect_setequal(observed$value, scorable$observed)
+  expect_setequal(forecast$target, scorable$target)
 })
 
 
-testthat::test_that("score_hubverse handles missing location data", {
+testthat::test_that(paste0(
+  "quantile_table_to_scorable respects non-default inputs ",
+  "with valid default inputs"
+), {
+  scorable <- quantile_table_to_scorable(
+    forecast |> dplyr::rename(loc = "location"),
+    observed |> dplyr::rename(
+      different_value = "value",
+      loc = "location"
+    ),
+    obs_date_column = "reference_date",
+    obs_value_column = "different_value",
+    id_cols = c("loc", "target")
+  )
+  expect_true(scoringutils::is_forecast_quantile(scorable))
+  expect_setequal(forecast$location, scorable$loc)
+  expect_setequal(observed$value, scorable$observed)
+  expect_setequal(forecast$target, scorable$target)
+})
+
+
+
+testthat::test_that(paste0(
+  "quantile_table_to_scorable handles ",
+  "missing location or target data"
+), {
   forecast <- create_hubverse_table(
-    date_cols = seq(
+    date = seq(
       lubridate::ymd("2024-11-01"), lubridate::ymd("2024-11-29"),
       by = "day"
     ),
     horizon = c(0, 1),
     location = c("loc1", "loc2"),
     output_type = "quantile",
+    target = c(
+      "wk inc pathogen ed visits",
+      "daily prev pathogen admissions"
+    ),
     output_type_id = 1:19 / 20
   )
 
   observed <- create_observation_data(
-    date_cols = seq(
+    date = seq(
       lubridate::ymd("2024-11-01"), lubridate::ymd("2024-11-29"),
       by = "day"
     ),
-    location = c("loc1")
+    location = c("loc1"),
+    target = c("wk inc pathogen ed visits")
   )
 
   result <- quantile_table_to_scorable(
@@ -91,7 +166,13 @@ testthat::test_that("score_hubverse handles missing location data", {
     obs_date_column = "reference_date"
   )
   expect_false("loc2" %in% result$location)
+  expect_false("daily prev pathogen admissions" %in% result$target)
   expect_setequal(observed$location, result$location)
+  expect_setequal(
+    result$observed,
+    observed$value
+  )
+  expect_setequal(observed$target, result$target)
 })
 
 
@@ -111,16 +192,18 @@ testthat::test_that(paste0(
   )
 
   observed <- create_observation_data(
-    date_cols = seq(
+    date = seq(
       lubridate::ymd("2024-11-01"), lubridate::ymd("2024-11-02"),
       by = "day"
     ),
-    location = c("loc1")
+    location = c("loc1"),
+    target = "null target"
   )
 
   expect_error(
     result <- quantile_table_to_scorable(
-      forecast, observed,
+      forecast,
+      observed,
       obs_date_column = "reference_date"
     ),
     "Assertion on 'data' failed: Must have at least 1 rows, but has 0 rows."

--- a/vignettes/scoring-flu-forecasts.Rmd
+++ b/vignettes/scoring-flu-forecasts.Rmd
@@ -30,7 +30,7 @@ In this vignette, we use `forecasttools` to capture the current state of the Flu
 
 ### Generating a table of forecasts against truth data.
 
-First, we create a table of forecast predictions formatted to work with `scoringutils` functions using `hub_to_scorable_quantiles()`. Generally, we expect users to use `hub_to_scorable_quantiles()` with a local path to the forecast repository which updates from GitHub by default. In this case, we download the hub first.
+First, we create a table of quantile forecasts formatted to work with `scoringutils` functions using `hub_to_scorable_quantiles()`. Generally, we expect users to use `hub_to_scorable_quantiles()` with a local path to the forecast repository which updates from GitHub by default. In this case, we download a copy of the Hub from GitHub.
 
 ```{r}
 hub_url <- "https://github.com/cdcepi/FluSight-forecast-hub"
@@ -53,11 +53,23 @@ gert::git_branch_create(
 )
 ```
 
+The FluSight hub currently has a single "target" for quantile forecasts: epiweekly incident Influenza hospital admissions. It provides a timeseries of that data in a file named [`target-data/target-hospital-admissions.csv'](https://github.com/cdcepi/FluSight-forecast-hub/blob/6ae6919865417a2557773faa5f7354a0329baa4c/target-data/target-hospital-admissions.csv).
+
+Unlike the schema for forecasts, the schema for target data is not yet standardized across Hubs. `hub_to_scorable_quantiles()` asks you to provide the relative path to the target data you want within the hub, as well as what ID columns (besides date) should be used to join it to forecasts:
+
 ```{r}
-forecast_and_target <- hub_to_scorable_quantiles(hub_path)
+target_data_path <- fs::path("target-data",
+  "target-hospital-admissions",
+  ext = "csv"
+)
+forecast_and_target <- hub_to_scorable_quantiles(hub_path,
+  target_data_rel_path =
+    target_data_path,
+  id_cols = "location"
+)
 ```
 
-There are `r forecast_and_target$model_id |> unique() |> length()` different models that have been submitted to FluSight.
+There were `r forecast_and_target$model_id |> unique() |> length()` different models that had been submitted to FluSight as of the [copy examined in this vignette](https://github.com/cdcepi/FluSight-forecast-hub/commit/6ae69198654)
 
 ```{r}
 unique(forecast_and_target$model_id)

--- a/vignettes/scoring-flu-forecasts.Rmd
+++ b/vignettes/scoring-flu-forecasts.Rmd
@@ -55,7 +55,7 @@ gert::git_branch_create(
 
 The FluSight hub currently has a single "target" for quantile forecasts: epiweekly incident Influenza hospital admissions. It provides a timeseries of that data in a file named [`target-data/target-hospital-admissions.csv'](https://github.com/cdcepi/FluSight-forecast-hub/blob/6ae6919865417a2557773faa5f7354a0329baa4c/target-data/target-hospital-admissions.csv).
 
-Unlike the schema for forecasts, the schema for target data is not yet standardized across Hubs. `hub_to_scorable_quantiles()` asks you to provide the relative path to the target data you want within the hub, as well as what ID columns (besides date) should be used to join it to forecasts:
+Unlike the schema for forecasts, the schema for target data is not yet standardized across Hubs. `hub_to_scorable_quantiles()` asks you to provide the relative path to the target data you want within the hub, as well as what ID columns (besides `target_end_date`) should be used to join it to forecasts:
 
 ```{r}
 target_data_path <- fs::path("target-data",
@@ -69,10 +69,12 @@ forecast_and_target <- hub_to_scorable_quantiles(hub_path,
 )
 ```
 
-There were `r forecast_and_target$model_id |> unique() |> length()` different models that had been submitted to FluSight as of the [copy examined in this vignette](https://github.com/cdcepi/FluSight-forecast-hub/commit/6ae69198654)
+`hub_to_scorable_quantiles()` outputs a `scoringutils` object, specifically the output of `scoringutils::as_forecast_quantile()`. Note that while `hubData::collect_hub()` identifies individual models with a `model_id` column, `hub_to_scorable_quantiles` renames this to the `scoringutils` standard `model` column.
+
+There were `r forecast_and_target$model |> unique() |> length()` different models that had been submitted to FluSight as of the [copy examined in this vignette](https://github.com/cdcepi/FluSight-forecast-hub/commit/6ae69198654)
 
 ```{r}
-unique(forecast_and_target$model_id)
+unique(forecast_and_target$model)
 ```
 
 There are `r forecast_and_target$location |> unique() |> na.omit() |> length()` locations, either states or territories, for which there are available fforecasts. They are stored as two-digit codes, but can re-code them as the more familiar USPS-style two-letter abbreviations via `us_loc_code_to_abbr()`:
@@ -98,12 +100,12 @@ forecast_and_target |>
   filter(location == !!chosen_location) |>
   score() |>
   summarise_scores(
-    by = "model_id",
+    by = "model",
     relative_skill = TRUE,
     baseline = "FluSight-ensemble"
   ) |>
   summarise_scores(
-    by = "model_id",
+    by = "model",
     fun = signif,
     digits = 2
   ) |>


### PR DESCRIPTION
The functions to prepare hubs for scoring now no longer assume that forecast files contain a single target. This will be useful for multi-target hubs like the pyrenew minihub. Tests updated accordingly.

Note that the new defaults make this a breaking change for any scoring workflows that use truth data without a `target` column. This can be addressed by setting `id_cols` explicitly.