### PR TITLE
Switch from `arrow::{read, write}_parquet` to `nanoparquet::` equivalents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports:
-    arrow,
     checkmate,
     cli,
     copula,
@@ -42,6 +41,7 @@ Imports:
     jsonlite,
     lubridate,
     methods,
+    nanoparquet,
     purrr,
     readr,
     rlang,

--- a/R/utils.R
+++ b/R/utils.R
@@ -149,7 +149,7 @@ soql_nullable_select <- function(soql_list, columns) {
 #' file reader/writer function, which will be one of
 #' [readr::read_csv()] / [readr::write_csv()],
 #' [readr::read_tsv()] / [readr::write_tsv()], and
-#' [arrow::read_parquet()] / [arrow::write_parquet()],
+#' [nanoparquet::read_parquet()] / [nanoparquet::write_parquet()],
 #' depending on the file format.
 #' @return For `read_tabular_file`, the result of
 #' reading in the file, as a
@@ -165,7 +165,7 @@ read_tabular_file <- function(path_to_file,
   file_readers <- c(
     "tsv" = readr::read_tsv,
     "csv" = readr::read_csv,
-    "parquet" = arrow::read_parquet
+    "parquet" = nanoparquet::read_parquet
   )
 
   checkmate::assert_names(file_format,
@@ -187,7 +187,7 @@ write_tabular_file <- function(table,
   file_writers <- c(
     "tsv" = readr::write_tsv,
     "csv" = readr::write_csv,
-    "parquet" = arrow::write_parquet
+    "parquet" = nanoparquet::write_parquet
   )
 
   checkmate::assert_names(file_format,

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,0 +1,50 @@
+temp_dir <- withr::local_tempdir()
+withr::with_seed(5, {
+  test_table <- tibble::tibble(
+    x = 1:5,
+    y = LETTERS[x],
+    z = runif(5)
+  )
+})
+
+test_that(paste0(
+  "write_tabular_file and read_tabular_file are inverses ",
+  "for all valid file extensions"
+), {
+  purrr::map(
+    c("tsv", "csv", "parquet"),
+    \(ext) {
+      outpath <- fs::path(temp_dir,
+        "test_table",
+        ext = ext
+      )
+      write_tabular_file(test_table, outpath)
+      result <- read_tabular_file(outpath) |>
+        suppressMessages() |>
+        tibble::as_tibble()
+
+      expect_equal(result, test_table)
+    }
+  )
+})
+
+
+test_that(paste0(
+  "read_tabular_file and write_tabular_file error ",
+  "when passed invalid extensions"
+), {
+  purrr::map(c("acsv", "tsv_", "parquetb"), \(ext) {
+    outpath <- fs::path(temp_dir,
+      "test_table",
+      ext = ext
+    )
+    expect_error(
+      write_tabular_file(test_table, outpath),
+      "Names must be a subset of"
+    )
+    expect_error(
+      read_tabular_file(outpath),
+      "Names must be a subset of"
+    )
+  })
+})


### PR DESCRIPTION
Closes #95 

Also adds basic tests for `read_tabular_file()` and `write_tabular_file()`