### PR TITLE
vectorize `horizons_from_target_end_dates`

### DIFF
--- a/R/to_hubverse.R
+++ b/R/to_hubverse.R
@@ -44,9 +44,7 @@ target_end_dates_from_horizons <- function(reference_date,
 #' @export
 horizons_from_target_end_dates <- function(reference_date,
                                            target_end_dates,
-                                           horizon_timescale =
-                                             c("days", "weeks")) {
-  rlang::arg_match(horizon_timescale)
+                                           horizon_timescale) {
   horizons <- lubridate::time_length(target_end_dates - reference_date,
     unit = horizon_timescale
   )

--- a/man/horizons_from_target_end_dates.Rd
+++ b/man/horizons_from_target_end_dates.Rd
@@ -7,7 +7,7 @@
 horizons_from_target_end_dates(
   reference_date,
   target_end_dates,
-  horizon_timescale = c("days", "weeks")
+  horizon_timescale
 )
 }
 \arguments{

--- a/tests/testthat/test_to_hubverse.R
+++ b/tests/testthat/test_to_hubverse.R
@@ -113,4 +113,15 @@ test_that("horizons_from_target_end_dates works correctly", {
       horizon_timescale = "weeks"
     )
   )
+  expect_equal(
+    horizons_from_target_end_dates(
+      reference_date = lubridate::ymd("2000-01-01"),
+      target_end_dates = c(
+        lubridate::ymd("2000-01-01") + lubridate::ddays(1),
+        lubridate::ymd("2000-01-01") + lubridate::dweeks(1)
+      ),
+      horizon_timescale = c("days", "weeks")
+    ),
+    c(1, 1)
+  )
 })


### PR DESCRIPTION
This change shifts input validation to `lubridate::time_length`, which is a convenient way to allow us to vectorize the `horizon_timescale` argument:


``` r
forecasttools::horizons_from_target_end_dates(
  reference_date = lubridate::today(),
  target_end_dates = c(
    lubridate::today() + lubridate::ddays(1),
    lubridate::today() + lubridate::dweeks(1)
  ),
  horizon_timescale = c("days", "weeks")
)
#> [1] 1 1
```

<sup>Created on 2025-04-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>