### PR TITLE
Handle missing values in `trajectories_to_quantiles.R`

### DIFF
--- a/R/trajectories_to_quantiles.R
+++ b/R/trajectories_to_quantiles.R
@@ -52,7 +52,13 @@ trajectories_to_quantiles <- function(
       dplyr::across(dplyr::all_of(c(timepoint_cols, id_cols)))
     )
 
+  missing_groups <- grouped_df |>
+    summarize("any_missing" = any(is.na(.data$value_col)), .groups = "drop") |>
+    filter(.data$any_missing) |>
+    select(-"any_missing")
+
   quant_df <- grouped_df |>
+    dplyr::anti_join(missing_groups, by = colnames(missing_groups)) |>
     dplyr::reframe(
       !!quantile_value_name := stats::quantile(
         .data$value_col,

--- a/R/trajectories_to_quantiles.R
+++ b/R/trajectories_to_quantiles.R
@@ -53,9 +53,12 @@ trajectories_to_quantiles <- function(
     )
 
   missing_groups <- grouped_df |>
-    summarize("any_missing" = any(is.na(.data$value_col)), .groups = "drop") |>
-    filter(.data$any_missing) |>
-    select(-"any_missing")
+    dplyr::summarize(
+      "any_missing" = any(is.na(.data$value_col)),
+      .groups = "drop"
+    ) |>
+    dplyr::filter(.data$any_missing) |>
+    dplyr::select(-"any_missing")
 
   quant_df <- grouped_df |>
     dplyr::anti_join(missing_groups, by = colnames(missing_groups)) |>

--- a/tests/testthat/test_trajectories_to_quantiles.R
+++ b/tests/testthat/test_trajectories_to_quantiles.R
@@ -59,3 +59,27 @@ test_that("trajectories_to_quantiles works as expected with custom args", {
     )
   )
 })
+
+test_that("trajectories_to_quantiles works with missing values", {
+  timepoint_to_na <- as.Date("2023-10-21")
+  draw_to_na <- 18
+  dat <- forecasttools::example_daily_forecast_flu |>
+    dplyr::rename(
+      value = "hosp",
+      timepoint = "date"
+    ) |>
+    dplyr::filter(location == "NM") |>
+    dplyr::mutate(
+      value = dplyr::if_else(
+        timepoint == timepoint_to_na & .draw == draw_to_na,
+        NaN,
+        value
+      )
+    )
+
+  quants <- trajectories_to_quantiles(dat)
+
+  present_timepoints <- unique(quants$timepoint)
+  expected_timepoints <- setdiff(unique(dat$timepoint), timepoint_to_na)
+  expect_true(setequal(present_timepoints, expected_timepoints))
+})


### PR DESCRIPTION
Went with this option instead of `na.rm = TRUE` for the case when your value is `NaN`, which would result in a dishonest quantile calculation.