### PR TITLE
Add back `hubData` entry to `DESCRIPTION` `Remotes:` field.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: air-format
   - repo: https://github.com/etiennebacher/jarl-pre-commit
-    rev: 31002db1c54cba36c85efc2c10f6c913009d2bb7
+    rev: 0.5.0
     hooks:
       - id: jarl-check
         args: ["--fix"]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,6 +75,8 @@ URL: https://cdcgov.github.io/forecasttools/, https://github.com/CDCgov/forecast
 Depends:
     R (>= 4.5.0)
 LazyData: true
+Remotes:
+    github::hubverse-org/hubData
 Additional_repositories: https://hubverse-org.r-universe.dev
 BugReports: https://github.com/CDCgov/forecasttools/issues
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,7 @@ Depends:
     R (>= 4.5.0)
 LazyData: true
 Remotes:
-    github::hubverse-org/hubData
+    url::hubverse-org/hubData@*release
 Additional_repositories: https://hubverse-org.r-universe.dev
 BugReports: https://github.com/CDCgov/forecasttools/issues
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,7 @@ Depends:
     R (>= 4.5.0)
 LazyData: true
 Remotes:
-    url::hubverse-org/hubData@*release
+    github::hubverse-org/hubData@*release
 Additional_repositories: https://hubverse-org.r-universe.dev
 BugReports: https://github.com/CDCgov/forecasttools/issues
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,6 +77,5 @@ Depends:
 LazyData: true
 Remotes:
     github::hubverse-org/hubData@*release
-Additional_repositories: https://hubverse-org.r-universe.dev
 BugReports: https://github.com/CDCgov/forecasttools/issues
 Config/testthat/edition: 3


### PR DESCRIPTION
Otherwise, `pak` installation (which we recommend in the readme) will fail unless the user either (a) manually installs `hubData` first or (b) configures their `repos` to include the hubverse R-universe.

We could instruct the user to do either, but I think this is less fraught for now.

Have set the `Remotes:` entry to point at the latest release of hubData per https://remotes.r-lib.org/#usage, which should mitigate the involved in either pointing at a specific version (as we did previously) or at the bleeding edge.